### PR TITLE
Callback hook

### DIFF
--- a/src/cowboy_social_hook.erl
+++ b/src/cowboy_social_hook.erl
@@ -1,0 +1,14 @@
+%%
+%% @doc Behavior for a post-callback hook.
+%%
+
+-module(cowboy_social_hook).
+
+-type token_props() :: [{atom(), binary()}].
+-export_type([token_props/0]).
+
+%% XXX - R15B required for this syntax
+-callback execute(TokenProps, Req, State)
+  -> {ok, TokenProps, Req, State}
+  | {error, binary(), Req, State}
+  when TokenProps::token_props(), Req::cowboy:req(), State::any().


### PR DESCRIPTION
Allows provider configuration to specify `callback_hooks`, an array of modules which implement the `cowboy_social_hook` behavior. After receiving the token, either via the callback endpoint or authorization code, each callback module's `execute` function will be called in the order configured.

Still requires documentation -- I'll add it if this direction sounds good!

For dvv/social#2.
