### PR TITLE
fixes so that erlang.mk compile works

### DIFF
--- a/src/cowboy_social_google.erl
+++ b/src/cowboy_social_google.erl
@@ -6,8 +6,8 @@
 -author('Vladimir Dronnikov <dronnikov@gmail.com>').
 
 -export([
-    % authorize/1,
-    % access_token/2,
+    authorize/1,
+    access_token/2,
     user_profile/2
   ]).
 

--- a/src/social.app.src
+++ b/src/social.app.src
@@ -1,6 +1,7 @@
 {application, social, [
   {description, "OAuth2 social login client for Cowboy web server"},
   {vsn, "0.0.1"},
+  {modules, []},
   {registered, []},
   {applications, [
     kernel,


### PR DESCRIPTION
erlang.mk has `-Werror` on by default, so the warnings were breaking the build, and relx was giving errors for .app.src.

I'll bet there was a good reason for commenting out those exports, but this is what I have to do to get it working with erlang.mk. I did remove `-Werror` from erlang.mk for awhile, but I actually kind of like it :)
